### PR TITLE
python3 + some refactoring

### DIFF
--- a/dj_datadog/middleware.py
+++ b/dj_datadog/middleware.py
@@ -1,30 +1,34 @@
 # std lib
 import time
 import traceback
+
 try:
     import json
 except ImportError:
     import simplejson as json
+
+# six
+from six import integer_types, string_types
 
 # django
 from django.conf import settings
 from django.http import Http404
 
 # datadog
-from datadog import initialize, api
-from datadog import statsd
+from datadog import api, initialize, statsd
+
 
 # init datadog api
 initialize(api_key=settings.DATADOG_API_KEY, app_key=settings.DATADOG_APP_KEY)
 
 
 class DatadogMiddleware(object):
-    DD_TIMING_ATTRIBUTE = '_dd_start_time'
+    DD_TIMING_ATTRIBUTE = '_datadog_start_time'
 
     def __init__(self):
         app_name = settings.DATADOG_APP_NAME
         self.error_metric = '{0}.errors'.format(app_name)
-        self.timing_metric = '{0}.request_time'.format(app_name)
+        self.timing_metric = '{0}.response_time'.format(app_name)
         self.event_tags = [app_name, 'exception']
 
     def process_request(self, request):
@@ -36,11 +40,10 @@ class DatadogMiddleware(object):
             return response
 
         # Calculate request time and submit to Datadog
-        request_time = time.time() - getattr(request, self.DD_TIMING_ATTRIBUTE)
+        response_time = time.time() - getattr(request, self.DD_TIMING_ATTRIBUTE)
         tags = self._get_metric_tags(request)
 
-        api.Metric.send(metric=self.timing_metric, points=request_time, 
-                        tags=tags)
+        api.Metric.send(metric=self.timing_metric, points=response_time, tags=tags)
 
         return response
 
@@ -57,7 +60,7 @@ class DatadogMiddleware(object):
         # Make request.META json-serializable.
         szble = {}
         for k, v in request.META.items():
-            if isinstance(v, (list, basestring, bool, int, float, long)):
+            if isinstance(v, string_types + integer_types + (list, bool, float)):  # TODO: check within the list
                 szble[k] = v
             else:
                 szble[k] = str(v)
@@ -67,7 +70,9 @@ class DatadogMiddleware(object):
             .format(exc, json.dumps(szble, indent=2))
 
         # Submit the exception to Datadog
-        api.Event.create(title=title, text=text, tags=self.event_tags, 
+        api.Event.create(title=title,
+                         text=text,
+                         tags=self.event_tags,
                          aggregation_key=request.path,
                          alert_type='error')
 

--- a/setup.py
+++ b/setup.py
@@ -4,24 +4,22 @@ from setuptools import setup
 
 README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
 
-reqs = []
+reqs = ['datadog==0.12.0', 'six']
+
 if [sys.version_info[0], sys.version_info[1]] < [2, 7]:
     reqs.append("simplejson>=2.0.9")
 
 setup(
-    name = 'dj_datadog',
-    version = '0.1.1',
-    packages = [
-        'dj_datadog',
-        'dj_datadog.middleware'
-    ],
-    include_package_data = True,
-    license = 'BSD',
-    description = ' simple Django middleware for submitting timings and exceptions to Datadog.',
-    long_description = README,
-    author = 'Conor Branagan',
-    author_email = 'conor.branagan@gmail.com',
-    maintainer = "Kenny Rachuonyo",
-    maintainer_email = "kenny.rachuonyo@gmail.com",
-    install_requires = reqs + ['datadog==0.12.0']
+    name='dj_datadog',
+    version='0.1.1',
+    packages=['dj_datadog'],
+    include_package_data=True,
+    license='BSD',
+    description=' simple Django middleware for submitting timings and exceptions to Datadog.',
+    long_description=README,
+    author='Conor Branagan',
+    author_email='conor.branagan@gmail.com',
+    maintainer="Kenny Rachuonyo",
+    maintainer_email="kenny.rachuonyo@gmail.com",
+    install_requires=reqs
 )


### PR DESCRIPTION
Refactoring:
- `setup.py` syntax fixed in accordance with `PEP-8`
- new dependency - `six` library for seamless support of both python2 and python3 
- `setup.py` list of dependencies to be kept at the top of the file - easier to find and read
- drop redundant submodule `request_handler.py` from the middleware module (which had troubles on python3 - absolute import paths)
- `request_time` indicator renamed into `response_time`
- `_dd_start_time` attribute renamed into `_datadog_start_time`
